### PR TITLE
Fixed capitalization of GitHub

### DIFF
--- a/blog/2013-08-08_Mailpile_Launched.html
+++ b/blog/2013-08-08_Mailpile_Launched.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -141,7 +141,7 @@ picnic.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-11_Designing_Security.html
+++ b/blog/2013-08-11_Designing_Security.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -86,7 +86,7 @@
 
 <p>In this inaugural Mailpile Conversations video, two of our team members: Smari McCarthy & Brennan Novak discuss some of the importances and challenges of getting encryption right in an email interface!</p>
 
-<p>There is currently an active thread about this fun challenge, Follow along or participate at the Mailpile <a href="github.com/pagekite/Mailpile/issues/59" target="_blank">Github Issues</a></p>
+<p>There is currently an active thread about this fun challenge, Follow along or participate at the Mailpile <a href="github.com/pagekite/Mailpile/issues/59" target="_blank">GitHub Issues</a></p>
 
 <p>Music by:<br>
 "Dark Horizon" by <a href="http://mezmedallion.com" target="_blank">Mez Medallion</a><br>
@@ -122,7 +122,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-11_Designing_Security.md
+++ b/blog/2013-08-11_Designing_Security.md
@@ -8,7 +8,7 @@ Type: blog
 <p>&nbsp;</p>
 
 <p>In this inaugural Mailpile Conversations video, two of our team members: Smari McCarthy & Brennan Novak discuss some of the importances and challenges of getting encryption right in an email interface!</p>
-<p>There is currently an active thread about this fun challenge, Follow along or participate at the Mailpile <a href="github.com/pagekite/Mailpile/issues/59" target="_blank">Github Issues</a></p>
+<p>There is currently an active thread about this fun challenge, Follow along or participate at the Mailpile <a href="github.com/pagekite/Mailpile/issues/59" target="_blank">GitHub Issues</a></p>
 
 <p>Music by:<br>
 "Dark Horizon" by <a href="http://mezmedallion.com" target="_blank">Mez Medallion</a><br>

--- a/blog/2013-08-11_IndieGoGo_Update_1.html
+++ b/blog/2013-08-11_IndieGoGo_Update_1.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -125,7 +125,7 @@ e-mail encryption, verification and security. Check it out!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-15_Digging_Through_the_Details.html
+++ b/blog/2013-08-15_Digging_Through_the_Details.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -187,7 +187,7 @@ for helping us get there!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-20_Turning_Money_Into_Code.html
+++ b/blog/2013-08-20_Turning_Money_Into_Code.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -176,7 +176,7 @@ we'll keep you posted as we go along.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-21_IndieGoGo_Update_2.html
+++ b/blog/2013-08-21_IndieGoGo_Update_2.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -156,7 +156,7 @@ know you are, and we thank you too!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-08-30_Fonts_and_Copyright_Licenses.html
+++ b/blog/2013-08-30_Fonts_and_Copyright_Licenses.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -134,7 +134,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-05_IndieGoGo_Update_3.html
+++ b/blog/2013-09-05_IndieGoGo_Update_3.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -149,7 +149,7 @@ introduce some of our more generous new backers.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-05_PayPal_Freezes_Campaign_Funds.html
+++ b/blog/2013-09-05_PayPal_Freezes_Campaign_Funds.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -153,7 +153,7 @@ details</a>.)</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-06_IndieGoGo_Update_4.html
+++ b/blog/2013-09-06_IndieGoGo_Update_4.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -143,7 +143,7 @@ blog</a>.)</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-10_IndieGoGo_Update_5.html
+++ b/blog/2013-09-10_IndieGoGo_Update_5.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -138,7 +138,7 @@ see covered in these videos.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-10_Surveillance_Centralization.html
+++ b/blog/2013-09-10_Surveillance_Centralization.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -121,7 +121,7 @@ Music by:<br>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-11_Budget_and_Roadmap.html
+++ b/blog/2013-09-11_Budget_and_Roadmap.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -212,7 +212,7 @@ you gauge how well the project is doing.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-09-12_IndieGoGo_Update_6.html
+++ b/blog/2013-09-12_IndieGoGo_Update_6.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -135,7 +135,7 @@ previous updates on <a href="/blog/">our blog</a>:</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-10-11_The_Month_of_Dog_Fooding.html
+++ b/blog/2013-10-11_The_Month_of_Dog_Fooding.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -146,7 +146,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-10-31_DarkMail_and_Designing_Security.html
+++ b/blog/2013-10-31_DarkMail_and_Designing_Security.html
@@ -45,7 +45,7 @@
 			<li><a href="/#features" class="scroll-link">Features</a></li>
 			<li><a href="/donate/" class="scroll-link">Donate</a></li>
 			<li><a href="/blog/" class="scroll-link">Blog</a></li>
-			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
 		</ul>
 	</div>
 
@@ -159,7 +159,7 @@ left a lot of room for iterative improvement.</p>
 			<div class="one-third">
 				<h3>Downloads</h3>
 				<ul class="add-bottom">
-					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
 					<li>Bugs, Issues, & Ideas: <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">Go Here</a></li>
 				</ul>
 				<ul>

--- a/blog/2013-10-31_DarkMail_and_Secure_Protocols.html
+++ b/blog/2013-10-31_DarkMail_and_Secure_Protocols.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -171,7 +171,7 @@ left a lot of room for iterative improvement.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-11-01_IndieGoGo_Update_7.html
+++ b/blog/2013-11-01_IndieGoGo_Update_7.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -133,7 +133,7 @@ Smári</a>. </p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-11-18_Speaking_your_language.html
+++ b/blog/2013-11-18_Speaking_your_language.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -92,7 +92,7 @@
 <p>That is all to say that we hope you enjoy Mailpile in whichever language you speak - and if your native language isn't supported yet, feel free to contribute. To enable a translation, at the moment, you need to either set your environment variables appropriately or set the prefs.language variable in the command line interface: "set prefs.language = nl_NL" for instance, to switch to Dutch.</p>
 <p>We have designated a translation freeze for our first alpha release for January 2nd, 2014. Any translations arriving after that date will not be included in the alpha, although they will be merged in after the alpha version ships.</p>
 <h3>Getting Involved</h3>
-<p>If you're interested in contributing language translations to Mailpile, checkout the project <a href="https://www.transifex.com/projects/p/mailpile/">on Transifex</a> and submit a pull request to our <a href="http://github.com/pagekite/mailpile">Github</a> or get in touch with <a href="http://github.com/Ovnicraft">Ovnicraft</a> who has been awesomely spearheading the endeavor.</p>
+<p>If you're interested in contributing language translations to Mailpile, checkout the project <a href="https://www.transifex.com/projects/p/mailpile/">on Transifex</a> and submit a pull request to our <a href="http://github.com/pagekite/mailpile">GitHub</a> or get in touch with <a href="http://github.com/Ovnicraft">Ovnicraft</a> who has been awesomely spearheading the endeavor.</p>
 <p>Thanks again!</p>
 <!-- Page content ends -->
                 <p><script id='fbwj89d'>(function(i){var f,s=document.getElementById(i);f=document.createElement('iframe');f.src='//api.flattr.com/button/view/?uid=mailpile&button=compact&url='+encodeURIComponent(document.URL);f.title='Flattr';f.height=20;f.width=110;f.style.borderWidth=0;s.parentNode.insertBefore(f,s);})('fbwj89d');</script></p>
@@ -124,7 +124,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2013-11-18_Speaking_your_language.md
+++ b/blog/2013-11-18_Speaking_your_language.md
@@ -27,6 +27,6 @@ We have designated a translation freeze for our first alpha release for January 
 
 ### Getting Involved
 
-If you're interested in contributing language translations to Mailpile, checkout the project [on Transifex](https://www.transifex.com/projects/p/mailpile/) and submit a pull request to our [Github](http://github.com/pagekite/mailpile) or get in touch with [Ovnicraft](http://github.com/Ovnicraft) who has been awesomely spearheading the endeavor.
+If you're interested in contributing language translations to Mailpile, checkout the project [on Transifex](https://www.transifex.com/projects/p/mailpile/) and submit a pull request to our [GitHub](http://github.com/pagekite/mailpile) or get in touch with [Ovnicraft](http://github.com/Ovnicraft) who has been awesomely spearheading the endeavor.
 
 Thanks again!

--- a/blog/2013-11-23_A_Pound_of_Security.html
+++ b/blog/2013-11-23_A_Pound_of_Security.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -199,7 +199,7 @@ reading!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-01-12_A_Plan_For_Spam.html
+++ b/blog/2014-01-12_A_Plan_For_Spam.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -146,7 +146,7 @@ but it is an interesting one for sure and we do have a bunch of ideas:</p>
 <h3>Spam that isn't Spam</h3>
 <p>A lot of us get so much e-mail, that we think of even legitimate mail as
 a form of "spam".</p>
-<p>Newsletters, Twitter notifications, Github issues, messages from our
+<p>Newsletters, Twitter notifications, GitHub issues, messages from our
 banks... e-mail is the only real standard for delivering messages to
 people over the Internet and it is used for literally everything.
 Flagging those messages as spam would be wrong, but it would still be
@@ -226,7 +226,7 @@ some of the above features have been implemented.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-01-12_A_Plan_For_Spam.md
+++ b/blog/2014-01-12_A_Plan_For_Spam.md
@@ -76,7 +76,7 @@ but it is an interesting one for sure and we do have a bunch of ideas:
 A lot of us get so much e-mail, that we think of even legitimate mail as
 a form of "spam".
 
-Newsletters, Twitter notifications, Github issues, messages from our
+Newsletters, Twitter notifications, GitHub issues, messages from our
 banks... e-mail is the only real standard for delivering messages to
 people over the Internet and it is used for literally everything.
 Flagging those messages as spam would be wrong, but it would still be

--- a/blog/2014-01-31_Alpha_Release_Shipping_Bits_and_Atoms.html
+++ b/blog/2014-01-31_Alpha_Release_Shipping_Bits_and_Atoms.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -135,7 +135,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-02-07_IndieGoGo_Update_8.html
+++ b/blog/2014-02-07_IndieGoGo_Update_8.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -130,7 +130,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-04-07_Workshop_in_London.html
+++ b/blog/2014-04-07_Workshop_in_London.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -148,7 +148,7 @@ few bugs as a result.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-04-30_Where_is_the_Community_Site.html
+++ b/blog/2014-04-30_Where_is_the_Community_Site.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -176,7 +176,7 @@ A handful of people have got in touch asking if we have considered <a href="http
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-06-03_Mailpile_Alpha_II.html
+++ b/blog/2014-06-03_Mailpile_Alpha_II.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -89,7 +89,7 @@ month now. We use it every day and we like it - we feel we are getting
 really close to having a working product for you guys.</p>
 <p>But you're hungry now, and it's high time for another appetizer.  So
 without further ado, we present <strong>Mailpile Alpha II - The Dogfood Edition!</strong>
-Yummy! This savoury mass of source code has been tagged in Github
+Yummy! This savoury mass of source code has been tagged in GitHub
 (<a href="https://github.com/pagekite/Mailpile/releases">release 0.2.0</a>)
 and we have updated our <a href="/demos/">live demos</a>. It's a little hard
 to summarize what all has changed (it would be easier to summarize what
@@ -144,7 +144,7 @@ which we will launch in just over a month. Our target date is August
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-06-03_Mailpile_Alpha_II.md
+++ b/blog/2014-06-03_Mailpile_Alpha_II.md
@@ -15,7 +15,7 @@ really close to having a working product for you guys.
 
 But you're hungry now, and it's high time for another appetizer.  So
 without further ado, we present **Mailpile Alpha II - The Dogfood Edition!**
-Yummy! This savoury mass of source code has been tagged in Github
+Yummy! This savoury mass of source code has been tagged in GitHub
 ([release 0.2.0](https://github.com/pagekite/Mailpile/releases))
 and we have updated our [live demos](/demos/). It's a little hard
 to summarize what all has changed (it would be easier to summarize what

--- a/blog/2014-08-08_Our_Upcoming_Beta_Release.html
+++ b/blog/2014-08-08_Our_Upcoming_Beta_Release.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -113,7 +113,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-08-20_Upcoming_Beta_Release_Part_II.html
+++ b/blog/2014-08-20_Upcoming_Beta_Release_Part_II.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -124,7 +124,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-09-13_Mailpile_Beta_Release.html
+++ b/blog/2014-09-13_Mailpile_Beta_Release.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -131,7 +131,7 @@ Download via: <a href="https://www.mailpile.is/files/releases/Mailpile-Installer
 
 <div class="add-bottom">
 <h5 class="half-bottom"><img src="/img/os-linux.png" border="0" style="height:24px;"> Linux</h5>
-As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on Github</a>
+As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on GitHub</a>
 </div>
 
 <p>So give it a spin, seed our torrents and let us know what you think. :-)</p>
@@ -170,7 +170,7 @@ post to discuss!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-09-13_Mailpile_Beta_Release.md
+++ b/blog/2014-09-13_Mailpile_Beta_Release.md
@@ -68,7 +68,7 @@ Download via: <a href="https://www.mailpile.is/files/releases/Mailpile-Installer
 
 <div class="add-bottom">
 <h5 class="half-bottom"><img src="/img/os-linux.png" border="0" style="height:24px;"> Linux</h5>
-As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on Github</a>
+As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on GitHub</a>
 </div>
 
 So give it a spin, seed our torrents and let us know what you think. :-)

--- a/blog/2014-10-07_Some_Thoughts_on_GnuPG.html
+++ b/blog/2014-10-07_Some_Thoughts_on_GnuPG.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -264,7 +264,7 @@ $ gpg --gen-key --name Smári McCarthy --email smari@mailpile.is --algorithm RSA
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/2014-11-21_To_PGP_MIME_Or_Not.html
+++ b/blog/2014-11-21_To_PGP_MIME_Or_Not.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -405,7 +405,7 @@ insights to share.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -588,7 +588,7 @@ Download via: <a href="https://www.mailpile.is/files/releases/Mailpile-Installer
 
 <div class="add-bottom">
 <h5 class="half-bottom"><img src="/img/os-linux.png" border="0" style="height:24px;"> Linux</h5>
-As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on Github</a>
+As a <a href="https://github.com/pagekite/Mailpile/releases" target="_blank">tagged source release on GitHub</a>
 </div>
 
 <p>So give it a spin, seed our torrents and let us know what you think. :-)</p>
@@ -678,7 +678,7 @@ post to discuss!</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/blog/index.rss
+++ b/blog/index.rss
@@ -516,7 +516,7 @@ Download via: &lt;a href=&#34;https://www.mailpile.is/files/releases/Mailpile-In
 
 &lt;div class=&#34;add-bottom&#34;&gt;
 &lt;h5 class=&#34;half-bottom&#34;&gt;&lt;img src=&#34;/img/os-linux.png&#34; border=&#34;0&#34; style=&#34;height:24px;&#34;&gt; Linux&lt;/h5&gt;
-As a &lt;a href=&#34;https://github.com/pagekite/Mailpile/releases&#34; target=&#34;_blank&#34;&gt;tagged source release on Github&lt;/a&gt;
+As a &lt;a href=&#34;https://github.com/pagekite/Mailpile/releases&#34; target=&#34;_blank&#34;&gt;tagged source release on GitHub&lt;/a&gt;
 &lt;/div&gt;
 
 &lt;p&gt;So give it a spin, seed our torrents and let us know what you think. :-)&lt;/p&gt;

--- a/demos/index.html
+++ b/demos/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -175,7 +175,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/demos/sorry.html
+++ b/demos/sorry.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -113,7 +113,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/donate/cancel.html
+++ b/donate/cancel.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 

--- a/donate/index.html
+++ b/donate/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 

--- a/donate/thanks.html
+++ b/donate/thanks.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 

--- a/download/index.html
+++ b/download/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -99,7 +99,7 @@
       <a href="https://github.com/pagekite/Mailpile/releases"><img src="/img/os-linux.png" style="height:48px;"></a><br>
       <h4 class="half-bottom">Linux</h4>
       Download via:<br>
-      <a href="https://github.com/pagekite/Mailpile/wiki/Getting-started-on-linux" target="_blank">Github (source code)</a>
+      <a href="https://github.com/pagekite/Mailpile/wiki/Getting-started-on-linux" target="_blank">GitHub (source code)</a>
     </div>
   </div>
 </div>
@@ -112,7 +112,7 @@
 <div class="row half-top text-center">
   <div class="col-14 col-offset-1">
     <h3><span class="icon-help"></span> Need Help?</h3>
-    <p>Read our full documentation and development guide on our <a href="https://github.com/pagekite/mailpile/wiki" target="_blank">Github Wiki</a>.<br> If you experience problems installing Mailpile, please let us know by <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">opening an issue</a> or <a href="mailto:team@mailpile.is?subject=Beta Feedback">email us</a>.<br> You can also <a href="https://twitter.com/mailpileteam" target="_blank">Tweet at us</a> or stop by our IRC room <strong>#mailpile</strong> on irc.freenode.net</p>
+    <p>Read our full documentation and development guide on our <a href="https://github.com/pagekite/mailpile/wiki" target="_blank">GitHub Wiki</a>.<br> If you experience problems installing Mailpile, please let us know by <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">opening an issue</a> or <a href="mailto:team@mailpile.is?subject=Beta Feedback">email us</a>.<br> You can also <a href="https://twitter.com/mailpileteam" target="_blank">Tweet at us</a> or stop by our IRC room <strong>#mailpile</strong> on irc.freenode.net</p>
   </div>
 </div>
 <hr>
@@ -215,7 +215,7 @@ $(document).ready(function() {
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/download/index.jinja
+++ b/download/index.jinja
@@ -41,7 +41,7 @@
       <a href="https://github.com/pagekite/Mailpile/releases"><img src="/img/os-linux.png" style="height:48px;"></a><br>
       <h4 class="half-bottom">Linux</h4>
       Download via:<br>
-      <a href="https://github.com/pagekite/Mailpile/wiki/Getting-started-on-linux" target="_blank">Github (source code)</a>
+      <a href="https://github.com/pagekite/Mailpile/wiki/Getting-started-on-linux" target="_blank">GitHub (source code)</a>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 <div class="row half-top text-center">
   <div class="col-14 col-offset-1">
     <h3><span class="icon-help"></span> Need Help?</h3>
-    <p>Read our full documentation and development guide on our <a href="https://github.com/pagekite/mailpile/wiki" target="_blank">Github Wiki</a>.<br> If you experience problems installing Mailpile, please let us know by <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">opening an issue</a> or <a href="mailto:team@mailpile.is?subject=Beta Feedback">email us</a>.<br> You can also <a href="https://twitter.com/mailpileteam" target="_blank">Tweet at us</a> or stop by our IRC room <strong>#mailpile</strong> on irc.freenode.net</p>
+    <p>Read our full documentation and development guide on our <a href="https://github.com/pagekite/mailpile/wiki" target="_blank">GitHub Wiki</a>.<br> If you experience problems installing Mailpile, please let us know by <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">opening an issue</a> or <a href="mailto:team@mailpile.is?subject=Beta Feedback">email us</a>.<br> You can also <a href="https://twitter.com/mailpileteam" target="_blank">Tweet at us</a> or stop by our IRC room <strong>#mailpile</strong> on irc.freenode.net</p>
   </div>
 </div>
 <hr>

--- a/faq/faq.html
+++ b/faq/faq.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -153,7 +153,7 @@ $(document).ready(function() {
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/faq/features.html
+++ b/faq/features.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -269,7 +269,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/faq/index.html
+++ b/faq/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -553,7 +553,7 @@ $(document).ready(function() {
 </li>
 <li class="faq-section-title" id="dev"><h2>Contributing, Helping, Developing</h2></li>
 <li class="faq-item" id="dev-1"> <h3 class="faq-title">I am a developer, how can I help?</h3> <span class="faq-section">dev</span>
-<p>You can take a look at our Github page and figure out if there's something to do there. </p>
+<p>You can take a look at our GitHub page and figure out if there's something to do there. </p>
 </li>
 <li class="faq-item" id="dev-2"> <h3 class="faq-title">I am not a techie, how can I help?</h3> <span class="faq-section">dev</span>
 <p>You can spread the word about the awesomeness of Mailpile! </p>
@@ -828,7 +828,7 @@ $(document).ready(function() {
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/faq/index.md
+++ b/faq/index.md
@@ -493,7 +493,7 @@ $(document).ready(function() {
 </li>
 <li class="faq-section-title" id="dev"><h2>Contributing, Helping, Developing</h2></li>
 <li class="faq-item" id="dev-1"> <h3 class="faq-title">I am a developer, how can I help?</h3> <span class="faq-section">dev</span>
-<p>You can take a look at our Github page and figure out if there's something to do there. </p>
+<p>You can take a look at our GitHub page and figure out if there's something to do there. </p>
 </li>
 <li class="faq-item" id="dev-2"> <h3 class="faq-title">I am not a techie, how can I help?</h3> <span class="faq-section">dev</span>
 <p>You can spread the word about the awesomeness of Mailpile! </p>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -246,7 +246,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/jinja/layouts/page.html-jinja
+++ b/jinja/layouts/page.html-jinja
@@ -56,7 +56,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 {%- endblock %}
@@ -119,7 +119,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/js/site.js
+++ b/js/site.js
@@ -70,11 +70,11 @@ jQuery(document).ready(function($){
         // Rank
         item.append('<a id="issue-' + item.data('issue') + '-rank" href="#" class="rank"><span class="icon-star"></span> Ranked ' + item.data('rank') + ' by Community</a>');
 
-        // Add Github Link
+        // Add GitHub Link
         if (item.data('comments')) {
-          item.append('<a id="issue-' + item.data('issue') + '-comments" href="' + link.attr('href') + '" class="comment" target="_blank"><span class="icon-comment"></span> ' + item.data('comments') + ' Comments on Github</a>');
+          item.append('<a id="issue-' + item.data('issue') + '-comments" href="' + link.attr('href') + '" class="comment" target="_blank"><span class="icon-comment"></span> ' + item.data('comments') + ' Comments on GitHub</a>');
         } else {
-          item.append('<a id="issue-' + item.data('issue') + '-comments" href="' + link.attr('href') + '" class="comment" target="_blank"><span class="icon-comment"></span> Comment on Github</a>');
+          item.append('<a id="issue-' + item.data('issue') + '-comments" href="' + link.attr('href') + '" class="comment" target="_blank"><span class="icon-comment"></span> Comment on GitHub</a>');
         }
 
         // Adjust CSS

--- a/press/2013-08-09_50000_USD_a_einni_viku.html
+++ b/press/2013-08-09_50000_USD_a_einni_viku.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -132,7 +132,7 @@ tölvupósti til <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#116;&#101;&#
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/press/2013-08-09_50000_USD_in_one_week.html
+++ b/press/2013-08-09_50000_USD_in_one_week.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -143,7 +143,7 @@ information security and network policy issues.</p>
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/press/index.html
+++ b/press/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -175,7 +175,7 @@ tölvupósti til <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#116;&#101;&#
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/providers/index.html
+++ b/providers/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -180,7 +180,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/roadmap/index.html
+++ b/roadmap/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -87,7 +87,7 @@
   <div id="roadmap-details" class="row clearfix hide">
     <div class="col-10">
       <h3>Prioritize our Roadmap</h3>
-      <p>Our roadmap consists of new features, ideas, and known bugs that we are aware of. Drag items in list to let us know what issues are of the highest priority to you and what you'd like to see fixed the fastest. To add an item please <a href="https://github.com/pagekite/mailpile/issues/new" target="_blank">file an issue on Github.</a></p>
+      <p>Our roadmap consists of new features, ideas, and known bugs that we are aware of. Drag items in list to let us know what issues are of the highest priority to you and what you'd like to see fixed the fastest. To add an item please <a href="https://github.com/pagekite/mailpile/issues/new" target="_blank">file an issue on GitHub.</a></p>
     </div>
     <div class="col-6">
       <h3>Vote on Decisions</h3>
@@ -201,7 +201,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/roadmap/index.jinja
+++ b/roadmap/index.jinja
@@ -29,7 +29,7 @@
   <div id="roadmap-details" class="row clearfix hide">
     <div class="col-10">
       <h3>Prioritize our Roadmap</h3>
-      <p>Our roadmap consists of new features, ideas, and known bugs that we are aware of. Drag items in list to let us know what issues are of the highest priority to you and what you'd like to see fixed the fastest. To add an item please <a href="https://github.com/pagekite/mailpile/issues/new" target="_blank">file an issue on Github.</a></p>
+      <p>Our roadmap consists of new features, ideas, and known bugs that we are aware of. Drag items in list to let us know what issues are of the highest priority to you and what you'd like to see fixed the fastest. To add an item please <a href="https://github.com/pagekite/mailpile/issues/new" target="_blank">file an issue on GitHub.</a></p>
     </div>
     <div class="col-6">
       <h3>Vote on Decisions</h3>

--- a/snippets/body.html
+++ b/snippets/body.html
@@ -9,7 +9,7 @@
 			<li><a href="/demos/" class="scroll-link">Demos</a></li>
 			<li><a href="/donate/" class="scroll-link">Donate</a></li>
 			<li><a href="/blog/" class="scroll-link">Blog</a></li>
-			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
 		</ul>
 	</div>
 

--- a/snippets/index.html
+++ b/snippets/index.html
@@ -45,7 +45,7 @@
 			<li><a href="/#features" class="scroll-link">Features</a></li>
 			<li><a href="/donate/" class="scroll-link">Donate</a></li>
 			<li><a href="/blog/" class="scroll-link">Blog</a></li>
-			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+			<li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
 		</ul>
 	</div>
 
@@ -93,7 +93,7 @@
 			<div class="one-third">
 				<h3>Downloads</h3>
 				<ul class="add-bottom">
-					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
 					<li>Bugs, Issues, & Ideas: <a href="https://github.com/pagekite/Mailpile/issues" target="_blank">Go Here</a></li>
 				</ul>
 				<ul>

--- a/snippets/tail.html
+++ b/snippets/tail.html
@@ -23,7 +23,7 @@
 			<div class="one-third">
 				<h3>Downloads</h3>
 				<ul class="add-bottom">
-					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+					<li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
 					<li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>

--- a/thank-you/index.html
+++ b/thank-you/index.html
@@ -53,7 +53,7 @@
             <li><a href="/demos/" class="scroll-link">Demos</a></li>
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li><a href="/blog/" class="scroll-link">Blog</a></li>
-            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">Github</a></li>
+            <li class="navigation-github"><a href="http://github.com/pagekite/Mailpile" target="_blank" class="scroll-link">GitHub</a></li>
         </ul>
     </div>
 
@@ -1310,7 +1310,7 @@
             <div class="one-third">
                 <h3>Downloads</h3>
                 <ul class="add-bottom">
-                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">Github</a></li>
+                    <li>Source Code: <a href="https://github.com/pagekite/Mailpile" target="_blank">GitHub</a></li>
                     <li>Bugs, Issues: <a href="https://github.com/pagekite/Mailpile/issues/new" target="_blank">Go Here</a></li>
           <li>Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=2&state=open" target="_blank"> Go Here</a></li>
           <li>Plugin Ideas: <a href="https://github.com/pagekite/Mailpile/issues?milestone=6&state=open" target="_blank"> Go Here</a></li>


### PR DESCRIPTION
I always get unproportionally annoyed when GitHub is spelt "Github", so I made some bash magic happen to correct that.
I went through the diff to make sure that my (lack of) bash skills didn't mess anything up, and it looked fine, but you should probably skim it just to make sure.