### PR TITLE
Clarify voters vs eligible people in blog post

### DIFF
--- a/blog/2015-07-02_Licensing_Decision.md
+++ b/blog/2015-07-02_Licensing_Decision.md
@@ -65,8 +65,8 @@ we could reach a conclusion everyone could abide by.
 Although these results clearly don't really meet that bar, all we can do
 is look for a silver lining.
 
-The fact is, voter participation in this election was quite low. The
-total number of voters was 3041, but we only had about 16.5% turnout.
+The fact is, voter participation in this election was quite low. 3041
+people in total were eligible for voting, but we only had about 16.5% turnout.
 Considering the subject matter (licensing, how dull!), it seems quite
 reasonable to assume this means most of our backers just don't care, one
 way or another. Even Stallman himself [commented](http://b.pagekite.me/blog/2015-06-15_Community_License_Feedback.html)


### PR DESCRIPTION
"voters" can be understood to mean only people who actually voted for _something_, which would then imply that even of those people who bothered visiting the voting page, only 16.5% had an opinion on the licensing question. This commit clarifies that 3041 is just the number of people who were eligible for voting at all.