### PR TITLE
added source download page

### DIFF
--- a/download/index.jinja
+++ b/download/index.jinja
@@ -51,6 +51,7 @@
 
 <div class="row half-top text-center">
   <p><strong>Note: our beta releases have some rough edges still, please read <a href="https://github.com/pagekite/Mailpile/wiki/Release-Notes-201507-Beta-III" target="_blank">our release notes</a>.<br> If you have  security concerns, <a href="https://github.com/pagekite/Mailpile/wiki/Security-roadmap" target="_blank">READ OUR SECURITY ROADMAP</a>, current implementation may not meet your needs!</strong></p>
+  <p>Source archives are available <a href="source.html">here</a>.
   <p>Packages were last updated on Monday, 2015-08-10.</p>
 </div>
 <hr>

--- a/download/source.jinja
+++ b/download/source.jinja
@@ -1,0 +1,32 @@
+{% extends "layouts/page.html-jinja" %}
+{% set page = {'type': 'full'} %}
+{% block title %}Source downloads{% endblock %}
+
+{% block content %}
+
+<h1 class="text-center">Source downloads</h1>
+
+{%
+set archives = [
+    ("0.5.2", "https://github.com/mailpile/Mailpile/archive/0.5.2.tar.gz"),
+    ("0.5.1", "https://github.com/mailpile/Mailpile/archive/0.5.1.tar.gz"),
+    ("0.5.0", "https://github.com/mailpile/Mailpile/archive/0.5.0.tar.gz"),
+    ("0.4.3", "https://github.com/mailpile/Mailpile/archive/0.4.3.tar.gz"),
+    ("0.4.2", "https://github.com/mailpile/Mailpile/archive/0.4.2.tar.gz"),
+    ("0.4.1", "https://github.com/mailpile/Mailpile/archive/0.4.1.tar.gz"),
+    ("0.4.0", "https://github.com/mailpile/Mailpile/archive/0.4.0.tar.gz"),
+    ("0.3.0", "https://github.com/mailpile/Mailpile/archive/0.3.0.tar.gz"),
+    ("0.2.0", "https://github.com/mailpile/Mailpile/archive/0.2.0.tar.gz"),
+    ("0.1.0", "https://github.com/mailpile/Mailpile/archive/0.1.0.tar.gz"),
+]
+%}
+
+<div class="text-center">
+    <ul>
+        {% for archive in archives %}
+            <li>mailpile-{{ archive[0] }} (<a href="{{ archive[1] }}">tarball</a>)</li>
+        {% endfor %}
+    </ul>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
Hello :)

This is my attempt at adding a source archives download page on the website.

This would be where distributions like Debian download the source tarball.

In the future, all you have to do is:
- ```make tarball``` on the main repo (see mailpile/Mailpile#1472))
- add release to the list in ```download/source.jinja```

Ideally, all future tarballs should be named with the same scheme. Something like ```mailpile-x.x.x``` would be recomended.