### PR TITLE
Prevent clicking on links in the answer from collapsing the FAQ item

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -140,8 +140,9 @@ $(document).ready(function() {
 
   $(document).on('click', '#faq-search', hide_toc);
 
-  $(document).on('click', 'li.faq-item', function() {
+  $(document).on('click', 'li.faq-item', function(e) {
     if ($(this).data('state') === 'open') {
+      if ($(e.target).is('a')) return;
       $(this).data('state', 'closed').removeClass('open');
       $(this).find('p').hide();
     }

--- a/faq/index.md
+++ b/faq/index.md
@@ -70,8 +70,9 @@ $(document).ready(function() {
 
   $(document).on('click', '#faq-search', hide_toc);
 
-  $(document).on('click', 'li.faq-item', function() {
+  $(document).on('click', 'li.faq-item', function(e) {
     if ($(this).data('state') === 'open') {
+      if ($(e.target).is('a')) return;
       $(this).data('state', 'closed').removeClass('open');
       $(this).find('p').hide();
     }

--- a/faq/top-snippet.html
+++ b/faq/top-snippet.html
@@ -64,8 +64,9 @@ $(document).ready(function() {
 
   $(document).on('click', '#faq-search', hide_toc);
 
-  $(document).on('click', 'li.faq-item', function() {
+  $(document).on('click', 'li.faq-item', function(e) {
     if ($(this).data('state') === 'open') {
+      if ($(e.target).is('a')) return;
       $(this).data('state', 'closed').removeClass('open');
       $(this).find('p').hide();
     }


### PR DESCRIPTION
**Previous behaviour:**
For example in [How does Mailpile compare with something like Hushmail? Protonmail? Whiteout?](https://www.mailpile.is/faq/#enc-12), clicking on the link `has already happened` (with Ctrl or Shift to open it in a new tab/window) would still make the reply collapse.

Nice work on Mailpile!