### PR TITLE
fixed blcked view on small screen w/o js

### DIFF
--- a/css/mailpile.css
+++ b/css/mailpile.css
@@ -2235,6 +2235,12 @@ ul {
   width: 100%;
   padding: 0px;
 }
+#menu_hidden_check:checked ~ .flexnav{
+  display:block;
+}
+.flexnav{
+  display:none;
+}
 .flexnav.with-js {
   max-height: 0;
 }
@@ -2386,6 +2392,7 @@ ul {
     padding-top: 0px;
   }
   .flexnav {
+    display:block;
     padding-top: 0px;
     margin-top: 0px;
     overflow: visible;

--- a/jinja/layouts/page.html-jinja
+++ b/jinja/layouts/page.html-jinja
@@ -50,8 +50,9 @@
 </head><body>
 {% block body %}
 {%- block navigation %}
-    <div id="navigation">
-      <div class="menu-button">Menu</div>
+    <nav id="navigation">
+        <input id="menu_hidden_check" hidden type="checkbox">
+        <label for="menu_hidden_check" class="menu-button">Menu</label>
         <ul data-breakpoint="800" class="flexnav">
             <li><a href="/" class="scroll-link" style="position: relative;">
               <img class="scroll-hint" src="/img/icon-48x48.png"
@@ -70,7 +71,7 @@
             <li><a href="/donate/" class="scroll-link">Donate</a></li>
             <li class="navigation-github"><a href="https://github.com/mailpile/Mailpile" target="_blank" class="scroll-link">Github</a></li>
         </ul>
-    </div>
+    </nav>
 {%- endblock %}
     <a style="position: absolute; top: 0;" name="top"></a>
 {% block github_banner %}


### PR DESCRIPTION
Used the [checkbox hack](https://css-tricks.com/the-checkbox-hack/) to fix the blocked view on small screens by navigation. Should close #12.
I took the liberty of updating the `<div id="navigation">` tag to HTML5 `<nav id="navigation">`, but smbdy should probably look through the code to change any `#navigation`-reference to plain `nav`.